### PR TITLE
Corrected Bug in `_process_data` function

### DIFF
--- a/gingerit/gingerit.py
+++ b/gingerit/gingerit.py
@@ -45,7 +45,8 @@ class GingerIt(object):
                 result = self._change_char(result, start, end, suggest['Text'])
 
                 corrections.append({
-                    'text': text[start:end],
+                    'start':start,
+                    'text': text[start:end+1],
                     'correct': suggest.get('Text', None),
                     'definition': suggest.get('Definition', None)
                 })


### PR DESCRIPTION
Changes :
========
1. _process_data function gives the wrong result in `corrections`. [misses one character in `text` of each correction]
After: 
![image](https://user-images.githubusercontent.com/19503624/60509799-75da5000-9ceb-11e9-810a-79bdf1a930b7.png)
Before:
![image](https://user-images.githubusercontent.com/19503624/60509854-930f1e80-9ceb-11e9-8489-e0c98df8c35e.png)


2. Added `start` to each `corrections` in result [To identify the particular one in case of multiple occurrences]